### PR TITLE
Fix #3 boostrapping- move script to bottom

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,12 +2,13 @@
 
   <head>
     <title>Angular2 Starter</title>
-    <script src="bundle.js"></script>
   </head>
 
   <body>
     <h1>Angular2 Starter</h1>
     <my-app></my-app>
+    
+    <script src="bundle.js"></script>
   </body>
 
 </html>


### PR DESCRIPTION
Possible fix for #3 
Move the script tag to the bottom of the body element.
