### PR TITLE
Fix #3 bootstrapping - wait for DOM to be ready

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -31,4 +31,6 @@ class MyAppComponent {
   }
 }
 
-bootstrap(MyAppComponent);
+document.addEventListener('DOMContentLoaded', function () {
+  bootstrap(MyAppComponent);
+});


### PR DESCRIPTION
Possible fix for #3 
Add an event listener for `DomContentLoaded` before bootstrapping
